### PR TITLE
Make the useEffect() function running only once

### DIFF
--- a/client/src/components/OfflineBanner.js
+++ b/client/src/components/OfflineBanner.js
@@ -7,17 +7,15 @@ const OfflineBanner = () => {
     function updateOnlineStatus() {
       setOnline(navigator.onLine);
     }
-
+    updateOnlineStatus();
     window.addEventListener("online", updateOnlineStatus);
     window.addEventListener("offline", updateOnlineStatus);
-    document.addEventListener("DOMContentLoaded", updateOnlineStatus);
 
     return () => {
       window.removeEventListener("online", updateOnlineStatus);
       window.removeEventListener("offline", updateOnlineStatus);
-      document.removeEventListener("DOMContentLoaded", updateOnlineStatus);
     };
-  });
+  }, []);
 
   return (
     <aside id={"offlineBanner"} className={isOnline ? "online" : "offline"}>


### PR DESCRIPTION
## Changes

- We need to set the listener "online / offline" only when the component is mounted, but not when it is updated, so I give   `useEffect()` an empty array as the second argument. [See here](https://github.com/nathanaelhoun/glowing-octo-guacamole/pull/73/files#diff-5892e175f1f574066dee03e339ed705afed38ffe9d42d5502ae99df64ba582f4R18)
- We need to set the online status when the connection status changes, but also when the component is mounted, in case where the user launches the app without connection, the "offline" event won't be triggered but we have to set the status to offline. [See here](https://github.com/nathanaelhoun/glowing-octo-guacamole/pull/73/files#diff-5892e175f1f574066dee03e339ed705afed38ffe9d42d5502ae99df64ba582f4R10)

Related to #70 
