### PR TITLE
Tests about token fixed

### DIFF
--- a/server/test/user.test.js
+++ b/server/test/user.test.js
@@ -25,14 +25,16 @@ describe("User login", function () {
         }
         expect(res.status).to.be.equal(200);
 
-        const expectedToken = jwt.sign(
-          { pseudo: "fpoguet" },
+        expect(Object.keys(res.body)).to.contains("pseudo");
+        expect(Object.keys(res.body)).to.contains("token");
+
+        let decodedToken = jwt.verify(
+          res.body.token,
           process.env.TOKEN_PRIVATE_KEY
         );
-        expect(res.body).to.be.deep.equal({
-          pseudo: "fpoguet",
-          token: expectedToken,
-        });
+
+        expect(Object.keys(decodedToken)).to.contains("pseudo");
+        expect(decodedToken.pseudo).to.be.equal("fpoguet");
 
         done();
       });


### PR DESCRIPTION
## Changes

In my tests, I generated two tokens with the same data to compare them, but the encryption method uses the timestamp, so we can have different tokens for the same data.

I changed this using the JWT verification method to validate a token.